### PR TITLE
Update lifetimes/exercise.rs

### DIFF
--- a/src/lifetimes/exercise.rs
+++ b/src/lifetimes/exercise.rs
@@ -60,7 +60,7 @@ impl From<u64> for WireType {
 }
 
 impl<'a> FieldValue<'a> {
-    fn as_string(&self) -> &'a str {
+    fn as_str(&self) -> &'a str {
         let FieldValue::Len(data) = self else {
             panic!("Expected string to be a `Len` field");
         };
@@ -186,7 +186,7 @@ struct Person<'a> {
 impl<'a> ProtoMessage<'a> for Person<'a> {
     fn add_field(&mut self, field: Field<'a>) {
         match field.field_num {
-            1 => self.name = field.value.as_string(),
+            1 => self.name = field.value.as_str(),
             2 => self.id = field.value.as_u64(),
             3 => self.phone.push(parse_message(field.value.as_bytes())),
             _ => {} // skip everything else
@@ -197,8 +197,8 @@ impl<'a> ProtoMessage<'a> for Person<'a> {
 impl<'a> ProtoMessage<'a> for PhoneNumber<'a> {
     fn add_field(&mut self, field: Field<'a>) {
         match field.field_num {
-            1 => self.number = field.value.as_string(),
-            2 => self.type_ = field.value.as_string(),
+            1 => self.number = field.value.as_str(),
+            2 => self.type_ = field.value.as_str(),
             _ => {} // skip everything else
         }
     }


### PR DESCRIPTION
Rename `as_string()` to `as_str()`. We are returning a `&str` not `String`. The latter name is also more idomatic and widely used.